### PR TITLE
Respect user's initial stop positions for first and last color when easing

### DIFF
--- a/plugin/helpers/gradient.ts
+++ b/plugin/helpers/gradient.ts
@@ -20,6 +20,11 @@ export function easeGradient(
     glColor(fill.gradientStops[fill.gradientStops.length - 1])
   ];
 
+  const colorStopPositions = [
+    fill.gradientStops[0].position,
+    fill.gradientStops[fill.gradientStops.length - 1].position
+  ];
+
   // cubic-bézier or step easing with timing values handed from ui
   const ease =
     type == 'curve'
@@ -29,14 +34,18 @@ export function easeGradient(
         )
       : easingCoordinates(`steps(${steps}, ${skip})`);
 
-  // map easibng to Figma ColorStop object
+  // map easing to Figma ColorStop object
   return ease.map(position => {
     const [r, g, b, a] = chroma
       .mix(colorStops[0], colorStops[1], position.y, 'rgb')
       .gl();
     return {
       color: { r, g, b, a },
-      position: position.x
+      position:
+        type == 'curve'
+          ? colorStopPositions[0] +
+            position.x * (colorStopPositions[1] - colorStopPositions[0])
+          : position.x
     };
   });
 }

--- a/plugin/helpers/gradient.ts
+++ b/plugin/helpers/gradient.ts
@@ -42,10 +42,8 @@ export function easeGradient(
     return {
       color: { r, g, b, a },
       position:
-        type == 'curve'
-          ? colorStopPositions[0] +
-            position.x * (colorStopPositions[1] - colorStopPositions[0])
-          : position.x
+        colorStopPositions[0] +
+        position.x * (colorStopPositions[1] - colorStopPositions[0])
     };
   });
 }

--- a/ui/App.vue
+++ b/ui/App.vue
@@ -154,8 +154,8 @@ export default Vue.extend({
        */
       hasColorStops: false,
       colorStops: {
-        stop1: { r: 0, g: 0, b: 0, a: 0 },
-        stop2: { r: 0, g: 0, b: 0, a: 0 },
+        stop1: { color: { r: 0, g: 0, b: 0, a: 0 }, position: 0 },
+        stop2: { color: { r: 0, g: 0, b: 0, a: 0 }, position: 1 },
         numStops: 2
       },
       selectionLength: 0,
@@ -261,8 +261,8 @@ export default Vue.extend({
           const c1 = fills[0];
           const c2 = fills[fills.length - 1];
           this.colorStops = {
-            stop1: c1.color,
-            stop2: c2.color,
+            stop1: c1,
+            stop2: c2,
             numStops: fills.length
           };
           this.hasColorStops = true;

--- a/ui/components/Editor/Editor.vue
+++ b/ui/components/Editor/Editor.vue
@@ -74,7 +74,7 @@
         <g>
           <rect
             :fill="
-              this.hasColorStops ? this.glColor(this.colorStops.stop1) : `#000`
+              this.hasColorStops ? this.glColor(this.colorStops.stop1.color) : `#000`
             "
             class="rect"
             vector-effect="non-scaling-stroke"
@@ -87,7 +87,7 @@
           />
           <rect
             :fill="
-              this.hasColorStops ? this.glColor(this.colorStops.stop2) : `#fff`
+              this.hasColorStops ? this.glColor(this.colorStops.stop2.color) : `#fff`
             "
             class="rect"
             vector-effect="non-scaling-stroke"

--- a/ui/components/Editor/Editor.vue
+++ b/ui/components/Editor/Editor.vue
@@ -128,8 +128,8 @@ type Steps = {
 };
 
 type ColorStops = {
-  stop1: { r: number; g: number; b: number; a: number };
-  stop2: { r: number; g: number; b: number; a: number };
+  stop1: { color: { r: number; g: number; b: number; a: number }; position: number };
+  stop2: { color: { r: number; g: number; b: number; a: number }; position: number };
 };
 
 export default Vue.extend({

--- a/ui/components/Preview.vue
+++ b/ui/components/Preview.vue
@@ -105,7 +105,7 @@ export default Vue.extend({
       curveSteps: 15, // How many color stops are used for easing. TODO: make this a prop?
       compareGradients: false,
       initColorStops: { stop1: '#000', stop2: '#fff' },
-      initColorStopPositions: { stop1Position: 0, stop2Position: 1 },
+      initColorStopPositions: { stop1Position: 0, stop2Position: 1 }
     };
   },
   components: {
@@ -168,11 +168,7 @@ export default Vue.extend({
       const easeGradient = ease.map(position => {
         return {
           color: chroma.mix(colorStop1, colorStop2, position.y, 'rgb').rgba(),
-          position:
-            this.type == 'curve'
-              ? stop1Position +
-                position.x * (stop2Position - stop1Position)
-              : position.x
+          position: stop1Position + position.x * (stop2Position - stop1Position)
         };
       });
 

--- a/ui/components/Preview.vue
+++ b/ui/components/Preview.vue
@@ -79,14 +79,19 @@ import { Tooltip } from 'figma-plugin-ds-vue';
 
 // Typings
 type ColorStops = {
-  stop1: { r: number; g: number; b: number; a: number };
-  stop2: { r: number; g: number; b: number; a: number };
+  stop1: { color: { r: number; g: number; b: number; a: number }; position: number };
+  stop2: { color: { r: number; g: number; b: number; a: number }; position: number };
   numStops: number;
 };
 
 type hexedColorStops = {
   colorStop1: string | Color;
   colorStop2: string | Color;
+};
+
+type colorStopPositions = {
+  stop1Position: number;
+  stop2Position: number;
 };
 
 export default Vue.extend({
@@ -99,7 +104,8 @@ export default Vue.extend({
     return {
       curveSteps: 15, // How many color stops are used for easing. TODO: make this a prop?
       compareGradients: false,
-      initColorStops: { stop1: '#000', stop2: '#fff' }
+      initColorStops: { stop1: '#000', stop2: '#fff' },
+      initColorStopPositions: { stop1Position: 0, stop2Position: 1 },
     };
   },
   components: {
@@ -148,6 +154,7 @@ export default Vue.extend({
      */
     easedGradient(): string {
       const { colorStop1, colorStop2 } = this.getColorStops;
+      const { stop1Position, stop2Position } = this.getColorStopPositions;
 
       const ease =
         this.type == 'curve'
@@ -161,7 +168,11 @@ export default Vue.extend({
       const easeGradient = ease.map(position => {
         return {
           color: chroma.mix(colorStop1, colorStop2, position.y, 'rgb').rgba(),
-          position: position.x
+          position:
+            this.type == 'curve'
+              ? stop1Position +
+                position.x * (stop2Position - stop1Position)
+              : position.x
         };
       });
 
@@ -182,9 +193,14 @@ export default Vue.extend({
       ) {
         return `background: radial-gradient(50% 50% at 50% 50%, ${inlineStyle.toString()});`;
       } else if (this.gradientType == 'GRADIENT_ANGULAR') {
+        // Figma "wraps" conic gradients by putting the start and end color at +/- 360 degrees from their original positions
+        const startColor = easeGradient[0];
+        const startColorString = `rgba(${startColor.color[0]}, ${startColor.color[1]}, ${startColor.color[2]}, ${startColor.color[3]}) ${(startColor.position + 1) * 100}%`;
+        const endColor = easeGradient[easeGradient.length - 1];
+        const endColorString = `rgba(${endColor.color[0]}, ${endColor.color[1]}, ${endColor.color[2]}, ${endColor.color[3]}) ${(endColor.position - 1) * 100}%`;
         return `background: conic-gradient(from ${
           this.offsetDegree
-        }deg at 50% 50%, ${inlineStyle.toString()});`;
+        }deg at 50% 50%, ${endColorString}, ${inlineStyle.toString()}, ${startColorString});`;
       }
       // Fallback to linear
       else {
@@ -198,19 +214,23 @@ export default Vue.extend({
      */
     linearGradient(): string {
       const { colorStop1, colorStop2 } = this.getColorStops;
+      const { stop1Position, stop2Position } = this.getColorStopPositions;
 
       // Handle different gradient types
       if (this.gradientType == 'GRADIENT_LINEAR') {
-        return `background: linear-gradient(${this.offsetDegree}deg, ${colorStop1} 0%, ${colorStop2} 100%);`;
+        return `background: linear-gradient(${this.offsetDegree}deg, ${colorStop1} ${stop1Position * 100}%, ${colorStop2} ${stop2Position * 100}%);`;
       } else if (
         this.gradientType == 'GRADIENT_RADIAL' ||
         this.gradientType == 'GRADIENT_DIAMOND'
       ) {
-        return `background: radial-gradient(50% 50% at 50% 50%, ${colorStop1} 0%, ${colorStop2} 100%);`;
+        return `background: radial-gradient(50% 50% at 50% 50%, ${colorStop1} ${stop1Position * 100}%, ${colorStop2} ${stop2Position * 100}%);`;
       } else if (this.gradientType == 'GRADIENT_ANGULAR') {
-        return `background: conic-gradient(from ${this.offsetDegree}deg at 50% 50%, ${colorStop1} 0%, ${colorStop2} 100%);`;
+        // Figma "wraps" conic gradients by putting the start and end color at +/- 360 degrees from their original positions
+        const startColorString = `${colorStop1} ${(stop1Position + 1) * 100}%`;
+        const endColorString = `${colorStop2} ${(stop2Position - 1) * 100}%`;
+        return `background: conic-gradient(from ${this.offsetDegree}deg at 50% 50%, ${endColorString}, ${colorStop1} ${stop1Position * 100}%, ${colorStop2} ${stop2Position * 100}%, ${startColorString});`;
       } else {
-        return `background: linear-gradient(${this.offsetDegree}deg, ${colorStop1} 0%, ${colorStop2} 100%);`;
+        return `background: linear-gradient(${this.offsetDegree}deg, ${colorStop1} ${stop1Position * 100}%, ${colorStop2} ${stop2Position * 100}%);`;
       }
     },
     /**
@@ -219,13 +239,25 @@ export default Vue.extend({
     getColorStops(): hexedColorStops {
       const c = this.colorStops;
       const colorStop1 = this.hasColorStops
-        ? chroma.gl(c.stop1.r, c.stop1.g, c.stop1.b, c.stop1.a)
+        ? chroma.gl(c.stop1.color.r, c.stop1.color.g, c.stop1.color.b, c.stop1.color.a)
         : this.initColorStops.stop1;
       const colorStop2 = this.hasColorStops
-        ? chroma.gl(c.stop2.r, c.stop2.g, c.stop2.b, c.stop2.a)
+        ? chroma.gl(c.stop2.color.r, c.stop2.color.g, c.stop2.color.b, c.stop2.color.a)
         : this.initColorStops.stop2;
 
       return { colorStop1, colorStop2 };
+    },
+    /**
+     * Utility to get positions of the supplied colorstops
+     */
+    getColorStopPositions(): colorStopPositions {
+      const c = this.colorStops;
+      const stop1Position = this.hasColorStops
+        ? c.stop1.position : this.initColorStopPositions.stop1Position;
+      const stop2Position = this.hasColorStops
+        ? c.stop2.position : this.initColorStopPositions.stop2Position;
+
+      return {stop1Position, stop2Position};
     },
     /**
      * The gradient rotation handed over from Figma has a different


### PR DESCRIPTION
E.g. If user sets their gradient stop positions to 20% and 80%, this will let the plugin interpolate the easing between those two stop points instead of easing from 0% to 100%.

re: Your previous comment about interpolating on the "outside" of the color stops - this could be a special case for the conic gradient, since it wraps back around to the start color, but for other gradients we don't need this. I'll leave that change to you if you decide to make it.

### Demo
![Screen Shot 2021-06-09 at 5 20 34 PM](https://user-images.githubusercontent.com/4770500/121431159-0b0a0880-c947-11eb-99a0-e8e62a80b804.png)



This also fixes an issue with the conic gradient preview in the plugin which was occurring when the stops are not at 0% and 100%. Figma does a weird thing where it wraps the conic gradient around to get rid of the sharp edge when there are no offsets at 0% and 100%. See sections commented `// Figma "wraps" conic gradients by putting the start and end color at +/- 360 degrees from their original positions`

I've only used Vue once before so pardon me if I made errors there, happy to fix :)

### Plugin preview before
![Screen Shot 2021-06-09 at 5 09 48 PM](https://user-images.githubusercontent.com/4770500/121430730-743d4c00-c946-11eb-8f8e-9962cbc70a0b.png)

### Plugin preview after
![Screen Shot 2021-06-09 at 5 10 00 PM](https://user-images.githubusercontent.com/4770500/121430738-77383c80-c946-11eb-9126-98f2e4250e2b.png)
