### PR TITLE
Fix last stop

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "semi": false,
+    "singleQuote": true
+}

--- a/src/utils/gradient.ts
+++ b/src/utils/gradient.ts
@@ -45,7 +45,7 @@ export function interpolateColorStops(
 					`cubic-bezier(
 						${matrix[0][0]},
 						${matrix[0][1]},
-						${matrix[1][0]},${matrix![0][0]})`,
+						${matrix[1][0]},${matrix[1][1]})`,
 					granularity
 			  )
 			: easingCoordinates(`steps(${steps}, ${skip})`)


### PR DESCRIPTION
I think this is a misspelling.

Ends up passing the wrong value into the second gradient stop, causing incorrect appearance.

These are both comparing B→W interpolation to W→B interpolation with curve `[0,0.5,1,0.5]`

<img width="1305" alt="Screenshot 2022-06-23 at 11 53 10 AM" src="https://user-images.githubusercontent.com/355540/175341985-d8357b45-15d2-4155-9cc4-27eb1282f829.png">
e