### PR TITLE
Support multi-stop gradients

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,7 @@
 {
     "trailingComma": "es5",
     "tabWidth": 4,
+    "useTabs": true,
     "max_line_length": 120,
     "semi": false,
     "singleQuote": true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,7 @@
 {
     "trailingComma": "es5",
     "tabWidth": 4,
+    "max_line_length": 120,
     "semi": false,
     "singleQuote": true
 }

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,10 @@
     {
       "name": "Re-apply gradient easing",
       "command": "ReapplyEasing"
+    },
+    {
+      "name": "Reset gradient easing",
+      "command": "ResetEasing"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,11 @@
 				"name": "Re-apply gradient easing",
 				"main": "src/main.ts",
 				"ui": "src/ui.tsx"
+			},
+			"ResetEasing": {
+				"name": "Reset gradient easing",
+				"main": "src/main.ts",
+				"ui": "src/ui.tsx"
 			}
 		}
 	},

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,11 +72,7 @@ export default async function () {
 			KEY_ORIGINAL_FILLS
 		)
 		if (origGradients !== undefined) {
-			console.log(
-				`restored data from "${KEY_ORIGINAL_FILLS}": "${JSON.stringify(
-					origGradients
-				)}""`
-			)
+			console.log(`restored data from "${KEY_ORIGINAL_FILLS}"`)
 			// TODO: validate this data
 		}
 		const fills = node.fills

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,26 +1,26 @@
 import {
-	nodeIsGeometryMixin,
-	isGradientFillWithMultipleStops,
-	interpolateColorStops,
-	validateSelection,
-	getValueFromStoreOrInit,
-	setValueToStorage,
-	handleNotificationFromUI
+    nodeIsGeometryMixin,
+    isGradientFillWithMultipleStops,
+    interpolateColorStops,
+    validateSelection,
+    getValueFromStoreOrInit,
+    setValueToStorage,
+    handleNotificationFromUI,
 } from './utils'
 import {
-	on,
-	emit,
-	showUI,
-	cloneObject,
-	insertAfterNode
-	//collapseLayer
+    on,
+    emit,
+    showUI,
+    cloneObject,
+    insertAfterNode,
+    //collapseLayer
 } from '@create-figma-plugin/utilities'
 import {
-	DEFAULT_PRESETS,
-	DEFAULT_EASING_TYPE,
-	DEFAULT_MATRIX,
-	DEFAULT_STEPS,
-	DEFAULT_SKIP
+    DEFAULT_PRESETS,
+    DEFAULT_EASING_TYPE,
+    DEFAULT_MATRIX,
+    DEFAULT_STEPS,
+    DEFAULT_SKIP,
 } from './shared/default_values'
 import { PresetOptionValue } from './ui'
 
@@ -31,10 +31,10 @@ export type EasingType = 'CURVE' | 'STEPS'
 export type Matrix = number[][]
 export type SkipOption = 'skip-none' | 'skip-both' | 'start' | 'end'
 export type EasingOptions = {
-	type: EasingType
-	matrix: Matrix
-	steps: number
-	skip: string
+    type: EasingType
+    matrix: Matrix
+    steps: number
+    skip: string
 }
 
 const KEY_PLUGIN_DATA = 'easing-gradients-v2-data'
@@ -42,272 +42,304 @@ const KEY_PRESETS: StorageKey = 'easing-gradients-v2-presets'
 //const PREVIEW_ELEMENT_PREFIX = '[Preview]'
 
 export default async function () {
-	const ui: UISettings = { width: 280, height: 388 }
+    const ui: UISettings = { width: 280, height: 388 }
 
-	// See comment L87
-	// await figma.loadFontAsync({ family: 'Roboto', style: 'Regular' })
+    // See comment L87
+    // await figma.loadFontAsync({ family: 'Roboto', style: 'Regular' })
 
-	let selectionRef: SceneNode | undefined
-	let cloneRef: SceneNode | undefined
-	let labelRef: GroupNode | undefined
-	let state: EasingOptions = {
-		type: DEFAULT_EASING_TYPE,
-		matrix: DEFAULT_MATRIX,
-		steps: DEFAULT_STEPS,
-		skip: DEFAULT_SKIP
-	}
+    let selectionRef: SceneNode | undefined
+    let cloneRef: SceneNode | undefined
+    let labelRef: GroupNode | undefined
+    let state: EasingOptions = {
+        type: DEFAULT_EASING_TYPE,
+        matrix: DEFAULT_MATRIX,
+        steps: DEFAULT_STEPS,
+        skip: DEFAULT_SKIP,
+    }
 
-	/**
-	 * Functions
-	 */
-	function updateGradientFill(node: SceneNode): void {
-		if (!node) return console.error(`Couldn't get node.`)
-		if (!nodeIsGeometryMixin(node))
-			return console.warn('Selected node is not a shape.')
-		const fills = node.fills as Paint[]
+    /**
+     * Functions
+     */
+    function updateGradientFill(node: SceneNode): void {
+        if (!node) return console.error(`Couldn't get node.`)
+        if (!nodeIsGeometryMixin(node))
+            return console.warn('Selected node is not a shape.')
 
-		fills.forEach((fillProperty, index) => {
-			if (!isGradientFillWithMultipleStops(fillProperty))
-				return console.warn(
-					'Selected node does not contain gradient fills.'
-				)
+        const dataKey = 'originalFills'
 
-			const tempNode: any = cloneObject(node.fills)
+        // if we have already been applied to this node, restore the original gradient stops before re-applying
+        const orig = node.getPluginData(dataKey)
+        let origGradients: GradientPaint[] | undefined
+        if (orig !== undefined && orig.length > 0) {
+            console.log(`restored data from "${dataKey}": "${orig}""`)
+            // TODO: validate this data
+            origGradients = JSON.parse(orig) as GradientPaint[]
+        }
+        const fills = node.fills
+        if (fills == figma.mixed) {
+            return console.warn('Selected node has mixed fills.')
+        }
 
-			tempNode[index].gradientStops = interpolateColorStops(
-				fillProperty,
-				state
-			)
-			node.fills = tempNode
-		})
-	}
+        // Save the gradient fills from before we modified them
+        const save = origGradients
+            ? origGradients
+            : fills.filter((f) => isGradientFillWithMultipleStops(f))
+        node.setPluginData(dataKey, JSON.stringify(save))
 
-	/**
-	 * ⚠️ The preview label is causing some issues in Version 8,
-	 * but right now I don't have capacity to investigate.
-	 * Since this feature has no priority, I'll disable it for Version 9.
-	 */
+        const tempFills = cloneObject(
+            fills
+        ) as Paint[] /* remove readonly with cast */
 
-	// function createPreviewLabel(): GroupNode | void {
-	// 	if (!cloneRef) return
-	// 	let elements = []
-	// 	const baseHeight = 12
-	// 	const baseWidth = 34
-	// 	const zoom = figma.viewport.zoom / 1.6 // adjust viewport-relative scaling, guessed value
-	// 	const width = baseWidth / zoom
-	// 	const height = baseHeight / zoom
-	// 	const fontSize = Math.max(8 / zoom, 1)
+        // If gradient fills are mixed with other fills, allow the user to add/remove fills and just assume that the gradient fill indices stay constant
+        let gradIndex = 0
+        fills.forEach((fillProperty, index) => {
+            if (!isGradientFillWithMultipleStops(fillProperty))
+                return console.warn(
+                    'Selected node does not contain gradient fills.'
+                )
+            if (origGradients && gradIndex < origGradients.length) {
+                // Assign a temp variable so type inference knows fillProperty and orig are both GradientFill
+                const orig = origGradients[gradIndex]
+                if (isGradientFillWithMultipleStops(orig)) {
+                    fillProperty = orig
+                }
+            }
 
-	// 	// label backdrop
-	// 	const rect: RectangleNode = figma.createRectangle()
-	// 	rect.resizeWithoutConstraints(width, height)
-	// 	const rectColor = { r: 0.094, g: 0.627, b: 0.984 } // #18A0FB aka. Figma blue
-	// 	rect.fills = [{ type: 'SOLID', color: rectColor }]
-	// 	rect.cornerRadius = height / 8
-	// 	// label text
-	// 	const text: TextNode = figma.createText()
-	// 	text.resizeWithoutConstraints(width, height)
-	// 	const textColor = { r: 1, g: 1, b: 1 } //#fff
-	// 	text.fills = [{ type: 'SOLID', color: textColor }]
-	// 	text.fontSize = fontSize
-	// 	text.textAlignHorizontal = 'CENTER'
-	// 	text.textAlignVertical = 'CENTER'
-	// 	text.characters = 'Preview'
+            tempFills[index] = {
+                ...fillProperty,
+                gradientStops: interpolateColorStops(fillProperty, state),
+            }
+            gradIndex++
+        })
+        node.fills = tempFills
+    }
 
-	// 	elements.push(rect, text)
-	// 	// label container
-	// 	const group: GroupNode = figma.group(elements, figma.currentPage)
-	// 	group.name = `${PREVIEW_ELEMENT_PREFIX} Label`
-	// 	const margin = 2 / zoom
-	// 	group.x = cloneRef.x
-	// 	group.y = cloneRef.y - height - margin
+    /**
+     * ⚠️ The preview label is causing some issues in Version 8,
+     * but right now I don't have capacity to investigate.
+     * Since this feature has no priority, I'll disable it for Version 9.
+     */
 
-	// 	collapseLayer(group)
-	// 	return group
-	// }
+    // function createPreviewLabel(): GroupNode | void {
+    // 	if (!cloneRef) return
+    // 	let elements = []
+    // 	const baseHeight = 12
+    // 	const baseWidth = 34
+    // 	const zoom = figma.viewport.zoom / 1.6 // adjust viewport-relative scaling, guessed value
+    // 	const width = baseWidth / zoom
+    // 	const height = baseHeight / zoom
+    // 	const fontSize = Math.max(8 / zoom, 1)
 
-	function updateCanvasPreview(): void {
-		if (!selectionRef || !cloneRef) return
-		selectionRef.locked = true
-		selectionRef.visible = false
+    // 	// label backdrop
+    // 	const rect: RectangleNode = figma.createRectangle()
+    // 	rect.resizeWithoutConstraints(width, height)
+    // 	const rectColor = { r: 0.094, g: 0.627, b: 0.984 } // #18A0FB aka. Figma blue
+    // 	rect.fills = [{ type: 'SOLID', color: rectColor }]
+    // 	rect.cornerRadius = height / 8
+    // 	// label text
+    // 	const text: TextNode = figma.createText()
+    // 	text.resizeWithoutConstraints(width, height)
+    // 	const textColor = { r: 1, g: 1, b: 1 } //#fff
+    // 	text.fills = [{ type: 'SOLID', color: textColor }]
+    // 	text.fontSize = fontSize
+    // 	text.textAlignHorizontal = 'CENTER'
+    // 	text.textAlignVertical = 'CENTER'
+    // 	text.characters = 'Preview'
 
-		cloneRef.locked = true
+    // 	elements.push(rect, text)
+    // 	// label container
+    // 	const group: GroupNode = figma.group(elements, figma.currentPage)
+    // 	group.name = `${PREVIEW_ELEMENT_PREFIX} Label`
+    // 	const margin = 2 / zoom
+    // 	group.x = cloneRef.x
+    // 	group.y = cloneRef.y - height - margin
 
-		// see L87
-		// if (!labelRef) {
-		// 	labelRef = createPreviewLabel() || undefined
-		// } else {
-		// 	labelRef.locked = true
+    // 	collapseLayer(group)
+    // 	return group
+    // }
 
-		// 	cloneRef.name = `${PREVIEW_ELEMENT_PREFIX} Easing Gradients`
-		// 	insertAfterNode(cloneRef, selectionRef)
-		// 	insertAfterNode(labelRef, selectionRef)
-		// }
+    function updateCanvasPreview(): void {
+        if (!selectionRef || !cloneRef) return
+        selectionRef.locked = true
+        selectionRef.visible = false
 
-		updateGradientFill(cloneRef)
-	}
+        cloneRef.locked = true
 
-	function cleanUpCanvasPreview(): void {
-		if (!selectionRef || !cloneRef) return
-		selectionRef.locked = false
-		selectionRef.visible = true
-		selectionRef = undefined
+        // see L87
+        // if (!labelRef) {
+        // 	labelRef = createPreviewLabel() || undefined
+        // } else {
+        // 	labelRef.locked = true
 
-		cloneRef.remove()
-		cloneRef = undefined
+        // 	cloneRef.name = `${PREVIEW_ELEMENT_PREFIX} Easing Gradients`
+        // 	insertAfterNode(cloneRef, selectionRef)
+        // 	insertAfterNode(labelRef, selectionRef)
+        // }
 
-		if (labelRef) {
-			labelRef.remove()
-			labelRef = undefined
-		}
-	}
+        updateGradientFill(cloneRef)
+    }
 
-	/**
-	 * Event handlers
-	 */
-	function handleSelectionChange() {
-		const selectionState = validateSelection(figma.currentPage.selection)
-		if (selectionState !== 'VALID') {
-			cleanUpCanvasPreview()
-		} else {
-			const selection = figma.currentPage.selection[0]
-			if (cloneRef) {
-				// handle user selecting preview node via layer menu
-				if (selection.id === cloneRef.id) {
-					cleanUpCanvasPreview()
-					figma.notify(`Cannot select the preview element.`)
-				} else {
-					cleanUpCanvasPreview()
-					selectionRef = selection
-					cloneRef = selectionRef.clone()
-					makeSureClonedNodeIsInPlace()
-					updateCanvasPreview()
-				}
-			} else {
-				selectionRef = selection
-				cloneRef = selectionRef.clone()
-				makeSureClonedNodeIsInPlace()
-				updateCanvasPreview()
-			}
-		}
-		const pluginData = checkIfExistingEasingData(selectionRef)
-		emit('UPDATE_SELECTION_STATE', { selectionState, pluginData })
-	}
+    function cleanUpCanvasPreview(): void {
+        if (!selectionRef || !cloneRef) return
+        selectionRef.locked = false
+        selectionRef.visible = true
+        selectionRef = undefined
 
-	function handleUpdate(options: EasingOptions) {
-		state = { ...state, ...options }
-		updateCanvasPreview()
-	}
+        cloneRef.remove()
+        cloneRef = undefined
 
-	/**
-	 * Makes sure that the cloneRef node has the same position as it's selectionRef master.
-	 */
-	function makeSureClonedNodeIsInPlace(): void {
-		if (!selectionRef || !cloneRef) return
-		insertAfterNode(cloneRef, selectionRef)
-		if (selectionRef.parent?.type === 'GROUP') {
-			cloneRef.x = selectionRef.x
-			cloneRef.y = selectionRef.y
-		}
-	}
+        if (labelRef) {
+            labelRef.remove()
+            labelRef = undefined
+        }
+    }
 
-	/**
-	 * Handle preset getting/setting
-	 */
-	async function handleInitialPresetEmitToUI(): Promise<void> {
-		getValueFromStoreOrInit(KEY_PRESETS, DEFAULT_PRESETS)
-			.then((response: PresetOptionValue) => {
-				emit('INITIALLY_EMIT_PRESETS_TO_UI', response)
-			})
-			.catch(() => {
-				figma.notify(
-					`Couldn't load user presets, default presets will be used.`
-				)
-			})
-	}
+    /**
+     * Event handlers
+     */
+    function handleSelectionChange() {
+        const selectionState = validateSelection(figma.currentPage.selection)
+        if (selectionState !== 'VALID') {
+            cleanUpCanvasPreview()
+        } else {
+            const selection = figma.currentPage.selection[0]
+            if (cloneRef) {
+                // handle user selecting preview node via layer menu
+                if (selection.id === cloneRef.id) {
+                    cleanUpCanvasPreview()
+                    figma.notify(`Cannot select the preview element.`)
+                } else {
+                    cleanUpCanvasPreview()
+                    selectionRef = selection
+                    cloneRef = selectionRef.clone()
+                    makeSureClonedNodeIsInPlace()
+                    updateCanvasPreview()
+                }
+            } else {
+                selectionRef = selection
+                cloneRef = selectionRef.clone()
+                makeSureClonedNodeIsInPlace()
+                updateCanvasPreview()
+            }
+        }
+        const pluginData = checkIfExistingEasingData(selectionRef)
+        emit('UPDATE_SELECTION_STATE', { selectionState, pluginData })
+    }
 
-	async function handleReceivePresetsFromUI(data: any): Promise<void> {
-		const { presets, message } = data
-		setValueToStorage(KEY_PRESETS, presets)
-			.then((response: PresetOptionValue) => {
-				emit('RESPOND_TO_PRESETS_UPDATE', { response, message })
-				figma.notify(
-					message === 'ADD' ? 'Added new preset.' : 'Removed preset.'
-				)
-			})
-			.catch(() => {
-				figma.notify(`Couldn't save preset, please try again.`)
-			})
-	}
+    function handleUpdate(options: EasingOptions) {
+        state = { ...state, ...options }
+        updateCanvasPreview()
+    }
 
-	async function handleResetPresetsToDefault(): Promise<void> {
-		setValueToStorage(KEY_PRESETS, DEFAULT_PRESETS)
-			.then((response: PresetOptionValue) => {
-				emit('RESPOND_TO_PRESETS_UPDATE', {
-					response,
-					message: 'RESET'
-				})
-				figma.notify(
-					'Removed all presets and restored default presets.'
-				)
-			})
-			.catch(() => {
-				figma.notify(`Couldn't reset preset, please try again.`)
-			})
-	}
+    /**
+     * Makes sure that the cloneRef node has the same position as it's selectionRef master.
+     */
+    function makeSureClonedNodeIsInPlace(): void {
+        if (!selectionRef || !cloneRef) return
+        insertAfterNode(cloneRef, selectionRef)
+        if (selectionRef.parent?.type === 'GROUP') {
+            cloneRef.x = selectionRef.x
+            cloneRef.y = selectionRef.y
+        }
+    }
 
-	function applyEasingFunction(): void {
-		if (!selectionRef) return
-		selectionRef.setRelaunchData({
-			ReapplyEasing: `Re-applies gradient easing with respect to first and last color stop.`
-		})
-		selectionRef.setPluginData(KEY_PLUGIN_DATA, JSON.stringify(state))
+    /**
+     * Handle preset getting/setting
+     */
+    async function handleInitialPresetEmitToUI(): Promise<void> {
+        getValueFromStoreOrInit(KEY_PRESETS, DEFAULT_PRESETS)
+            .then((response: PresetOptionValue) => {
+                emit('INITIALLY_EMIT_PRESETS_TO_UI', response)
+            })
+            .catch(() => {
+                figma.notify(
+                    `Couldn't load user presets, default presets will be used.`
+                )
+            })
+    }
 
-		updateGradientFill(selectionRef)
-		cleanUpCanvasPreview()
-		figma.closePlugin()
-	}
+    async function handleReceivePresetsFromUI(data: any): Promise<void> {
+        const { presets, message } = data
+        setValueToStorage(KEY_PRESETS, presets)
+            .then((response: PresetOptionValue) => {
+                emit('RESPOND_TO_PRESETS_UPDATE', { response, message })
+                figma.notify(
+                    message === 'ADD' ? 'Added new preset.' : 'Removed preset.'
+                )
+            })
+            .catch(() => {
+                figma.notify(`Couldn't save preset, please try again.`)
+            })
+    }
 
-	function checkIfExistingEasingData(selection: any): any | undefined {
-		if (!selection) return
-		const pluginData = selection.getPluginData(KEY_PLUGIN_DATA)
-		if (pluginData) {
-			let data: any
-			try {
-				data = JSON.parse(pluginData)
-			} catch (e) {
-				return
-			}
-			return data
-		}
-	}
+    async function handleResetPresetsToDefault(): Promise<void> {
+        setValueToStorage(KEY_PRESETS, DEFAULT_PRESETS)
+            .then((response: PresetOptionValue) => {
+                emit('RESPOND_TO_PRESETS_UPDATE', {
+                    response,
+                    message: 'RESET',
+                })
+                figma.notify(
+                    'Removed all presets and restored default presets.'
+                )
+            })
+            .catch(() => {
+                figma.notify(`Couldn't reset preset, please try again.`)
+            })
+    }
 
-	/**
-	 * Event listeners
-	 */
-	on('UPDATE_FROM_UI', handleUpdate)
-	on('APPLY_EASING_FUNCTION', applyEasingFunction)
-	on('EMIT_PRESETS_TO_PLUGIN', handleReceivePresetsFromUI)
-	on('EMIT_PRESET_RESET_TO_PLUGIN', handleResetPresetsToDefault)
-	on('EMIT_NOTIFICATION_TO_PLUGIN', handleNotificationFromUI)
-	figma.on('selectionchange', handleSelectionChange)
-	figma.on('close', cleanUpCanvasPreview)
+    function applyEasingFunction(): void {
+        if (!selectionRef) return
+        selectionRef.setRelaunchData({
+            ReapplyEasing: `Re-applies gradient easing with respect to first and last color stop.`,
+        })
+        selectionRef.setPluginData(KEY_PLUGIN_DATA, JSON.stringify(state))
 
-	/**
-	 * If plugin was launched via RelaunchButton
-	 */
-	if (figma.command === 'ReapplyEasing') {
-		const selection = figma.currentPage.selection[0]
-		const pluginData = checkIfExistingEasingData(selection)
-		if (pluginData) {
-			state = pluginData
-			updateGradientFill(selection)
-			figma.notify('Re-applied gradient easing.', { timeout: 3 })
-			figma.closePlugin()
-		}
-	} else {
-		showUI(ui)
-		handleInitialPresetEmitToUI()
-		handleSelectionChange()
-	}
+        updateGradientFill(selectionRef)
+        cleanUpCanvasPreview()
+        figma.closePlugin()
+    }
+
+    function checkIfExistingEasingData(selection: any): any | undefined {
+        if (!selection) return
+        const pluginData = selection.getPluginData(KEY_PLUGIN_DATA)
+        if (pluginData) {
+            let data: any
+            try {
+                data = JSON.parse(pluginData)
+            } catch (e) {
+                return
+            }
+            return data
+        }
+    }
+
+    /**
+     * Event listeners
+     */
+    on('UPDATE_FROM_UI', handleUpdate)
+    on('APPLY_EASING_FUNCTION', applyEasingFunction)
+    on('EMIT_PRESETS_TO_PLUGIN', handleReceivePresetsFromUI)
+    on('EMIT_PRESET_RESET_TO_PLUGIN', handleResetPresetsToDefault)
+    on('EMIT_NOTIFICATION_TO_PLUGIN', handleNotificationFromUI)
+    figma.on('selectionchange', handleSelectionChange)
+    figma.on('close', cleanUpCanvasPreview)
+
+    /**
+     * If plugin was launched via RelaunchButton
+     */
+    if (figma.command === 'ReapplyEasing') {
+        const selection = figma.currentPage.selection[0]
+        const pluginData = checkIfExistingEasingData(selection)
+        if (pluginData) {
+            state = pluginData
+            updateGradientFill(selection)
+            figma.notify('Re-applied gradient easing.', { timeout: 3 })
+            figma.closePlugin()
+        }
+    } else {
+        showUI(ui)
+        handleInitialPresetEmitToUI()
+        handleSelectionChange()
+    }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,26 +1,26 @@
 import {
-    nodeIsGeometryMixin,
-    isGradientFillWithMultipleStops,
-    interpolateColorStops,
-    validateSelection,
-    getValueFromStoreOrInit,
-    setValueToStorage,
-    handleNotificationFromUI,
+	nodeIsGeometryMixin,
+	isGradientFillWithMultipleStops,
+	interpolateColorStops,
+	validateSelection,
+	getValueFromStoreOrInit,
+	setValueToStorage,
+	handleNotificationFromUI,
 } from './utils'
 import {
-    on,
-    emit,
-    showUI,
-    cloneObject,
-    insertAfterNode,
-    //collapseLayer
+	on,
+	emit,
+	showUI,
+	cloneObject,
+	insertAfterNode,
+	//collapseLayer
 } from '@create-figma-plugin/utilities'
 import {
-    DEFAULT_PRESETS,
-    DEFAULT_EASING_TYPE,
-    DEFAULT_MATRIX,
-    DEFAULT_STEPS,
-    DEFAULT_SKIP,
+	DEFAULT_PRESETS,
+	DEFAULT_EASING_TYPE,
+	DEFAULT_MATRIX,
+	DEFAULT_STEPS,
+	DEFAULT_SKIP,
 } from './shared/default_values'
 import { PresetOptionValue } from './ui'
 
@@ -31,10 +31,10 @@ export type EasingType = 'CURVE' | 'STEPS'
 export type Matrix = number[][]
 export type SkipOption = 'skip-none' | 'skip-both' | 'start' | 'end'
 export type EasingOptions = {
-    type: EasingType
-    matrix: Matrix
-    steps: number
-    skip: string
+	type: EasingType
+	matrix: Matrix
+	steps: number
+	skip: string
 }
 
 const KEY_PLUGIN_DATA = 'easing-gradients-v2-data'
@@ -43,335 +43,335 @@ const KEY_ORIGINAL_FILLS = 'originalFills'
 //const PREVIEW_ELEMENT_PREFIX = '[Preview]'
 
 export default async function () {
-    const ui: UISettings = { width: 280, height: 388 }
+	const ui: UISettings = { width: 280, height: 388 }
 
-    // See comment L87
-    // await figma.loadFontAsync({ family: 'Roboto', style: 'Regular' })
+	// See comment L87
+	// await figma.loadFontAsync({ family: 'Roboto', style: 'Regular' })
 
-    let selectionRef: SceneNode | undefined
-    let cloneRef: SceneNode | undefined
-    let labelRef: GroupNode | undefined
-    let state: EasingOptions = {
-        type: DEFAULT_EASING_TYPE,
-        matrix: DEFAULT_MATRIX,
-        steps: DEFAULT_STEPS,
-        skip: DEFAULT_SKIP,
-    }
+	let selectionRef: SceneNode | undefined
+	let cloneRef: SceneNode | undefined
+	let labelRef: GroupNode | undefined
+	let state: EasingOptions = {
+		type: DEFAULT_EASING_TYPE,
+		matrix: DEFAULT_MATRIX,
+		steps: DEFAULT_STEPS,
+		skip: DEFAULT_SKIP,
+	}
 
-    /**
-     * Functions
-     */
-    function updateGradientFill(node: SceneNode, reset: boolean = false): void {
-        if (!node) return console.error(`Couldn't get node.`)
-        if (!nodeIsGeometryMixin(node))
-            return console.warn('Selected node is not a shape.')
+	/**
+	 * Functions
+	 */
+	function updateGradientFill(node: SceneNode, reset: boolean = false): void {
+		if (!node) return console.error(`Couldn't get node.`)
+		if (!nodeIsGeometryMixin(node))
+			return console.warn('Selected node is not a shape.')
 
-        // if we have already been applied to this node, restore the original gradient stops before re-applying
-        const origGradients = safeGetPluginData<GradientPaint[]>(
-            node,
-            KEY_ORIGINAL_FILLS
-        )
-        if (origGradients !== undefined) {
-            console.log(
-                `restored data from "${KEY_ORIGINAL_FILLS}": "${JSON.stringify(
-                    origGradients
-                )}""`
-            )
-            // TODO: validate this data
-        }
-        const fills = node.fills
-        if (fills == figma.mixed) {
-            return console.warn('Selected node has mixed fills.')
-        }
+		// if we have already been applied to this node, restore the original gradient stops before re-applying
+		const origGradients = safeGetPluginData<GradientPaint[]>(
+			node,
+			KEY_ORIGINAL_FILLS
+		)
+		if (origGradients !== undefined) {
+			console.log(
+				`restored data from "${KEY_ORIGINAL_FILLS}": "${JSON.stringify(
+					origGradients
+				)}""`
+			)
+			// TODO: validate this data
+		}
+		const fills = node.fills
+		if (fills == figma.mixed) {
+			return console.warn('Selected node has mixed fills.')
+		}
 
-        // Save the gradient fills from before we modified them
-        const save = origGradients
-            ? origGradients
-            : fills.filter((f) => isGradientFillWithMultipleStops(f))
-        if (reset) {
-            node.setPluginData(KEY_ORIGINAL_FILLS, '')
-        } else {
-            node.setPluginData(KEY_ORIGINAL_FILLS, JSON.stringify(save))
-        }
+		// Save the gradient fills from before we modified them
+		const save = origGradients
+			? origGradients
+			: fills.filter((f) => isGradientFillWithMultipleStops(f))
+		if (reset) {
+			node.setPluginData(KEY_ORIGINAL_FILLS, '')
+		} else {
+			node.setPluginData(KEY_ORIGINAL_FILLS, JSON.stringify(save))
+		}
 
-        const tempFills = cloneObject(
-            fills
-        ) as Paint[] /* remove readonly with cast */
+		const tempFills = cloneObject(
+			fills
+		) as Paint[] /* remove readonly with cast */
 
-        // If gradient fills are mixed with other fills, allow the user to add/remove fills and just assume that the gradient fill indices stay constant
-        let gradIndex = 0
-        fills.forEach((fillProperty, index) => {
-            if (!isGradientFillWithMultipleStops(fillProperty))
-                return console.warn(
-                    'Selected node does not contain gradient fills.'
-                )
-            if (origGradients && gradIndex < origGradients.length) {
-                // Assign a temp variable so type inference knows fillProperty and orig are both GradientFill
-                const orig = origGradients[gradIndex]
-                if (isGradientFillWithMultipleStops(orig)) {
-                    fillProperty = orig
-                }
-            }
+		// If gradient fills are mixed with other fills, allow the user to add/remove fills and just assume that the gradient fill indices stay constant
+		let gradIndex = 0
+		fills.forEach((fillProperty, index) => {
+			if (!isGradientFillWithMultipleStops(fillProperty))
+				return console.warn(
+					'Selected node does not contain gradient fills.'
+				)
+			if (origGradients && gradIndex < origGradients.length) {
+				// Assign a temp variable so type inference knows fillProperty and orig are both GradientFill
+				const orig = origGradients[gradIndex]
+				if (isGradientFillWithMultipleStops(orig)) {
+					fillProperty = orig
+				}
+			}
 
-            tempFills[index] = {
-                ...fillProperty,
-                gradientStops: reset
-                    ? fillProperty.gradientStops
-                    : interpolateColorStops(fillProperty, state),
-            }
-            gradIndex++
-        })
-        node.fills = tempFills
-    }
+			tempFills[index] = {
+				...fillProperty,
+				gradientStops: reset
+					? fillProperty.gradientStops
+					: interpolateColorStops(fillProperty, state),
+			}
+			gradIndex++
+		})
+		node.fills = tempFills
+	}
 
-    /**
-     * ⚠️ The preview label is causing some issues in Version 8,
-     * but right now I don't have capacity to investigate.
-     * Since this feature has no priority, I'll disable it for Version 9.
-     */
+	/**
+	 * ⚠️ The preview label is causing some issues in Version 8,
+	 * but right now I don't have capacity to investigate.
+	 * Since this feature has no priority, I'll disable it for Version 9.
+	 */
 
-    // function createPreviewLabel(): GroupNode | void {
-    // 	if (!cloneRef) return
-    // 	let elements = []
-    // 	const baseHeight = 12
-    // 	const baseWidth = 34
-    // 	const zoom = figma.viewport.zoom / 1.6 // adjust viewport-relative scaling, guessed value
-    // 	const width = baseWidth / zoom
-    // 	const height = baseHeight / zoom
-    // 	const fontSize = Math.max(8 / zoom, 1)
+	// function createPreviewLabel(): GroupNode | void {
+	// 	if (!cloneRef) return
+	// 	let elements = []
+	// 	const baseHeight = 12
+	// 	const baseWidth = 34
+	// 	const zoom = figma.viewport.zoom / 1.6 // adjust viewport-relative scaling, guessed value
+	// 	const width = baseWidth / zoom
+	// 	const height = baseHeight / zoom
+	// 	const fontSize = Math.max(8 / zoom, 1)
 
-    // 	// label backdrop
-    // 	const rect: RectangleNode = figma.createRectangle()
-    // 	rect.resizeWithoutConstraints(width, height)
-    // 	const rectColor = { r: 0.094, g: 0.627, b: 0.984 } // #18A0FB aka. Figma blue
-    // 	rect.fills = [{ type: 'SOLID', color: rectColor }]
-    // 	rect.cornerRadius = height / 8
-    // 	// label text
-    // 	const text: TextNode = figma.createText()
-    // 	text.resizeWithoutConstraints(width, height)
-    // 	const textColor = { r: 1, g: 1, b: 1 } //#fff
-    // 	text.fills = [{ type: 'SOLID', color: textColor }]
-    // 	text.fontSize = fontSize
-    // 	text.textAlignHorizontal = 'CENTER'
-    // 	text.textAlignVertical = 'CENTER'
-    // 	text.characters = 'Preview'
+	// 	// label backdrop
+	// 	const rect: RectangleNode = figma.createRectangle()
+	// 	rect.resizeWithoutConstraints(width, height)
+	// 	const rectColor = { r: 0.094, g: 0.627, b: 0.984 } // #18A0FB aka. Figma blue
+	// 	rect.fills = [{ type: 'SOLID', color: rectColor }]
+	// 	rect.cornerRadius = height / 8
+	// 	// label text
+	// 	const text: TextNode = figma.createText()
+	// 	text.resizeWithoutConstraints(width, height)
+	// 	const textColor = { r: 1, g: 1, b: 1 } //#fff
+	// 	text.fills = [{ type: 'SOLID', color: textColor }]
+	// 	text.fontSize = fontSize
+	// 	text.textAlignHorizontal = 'CENTER'
+	// 	text.textAlignVertical = 'CENTER'
+	// 	text.characters = 'Preview'
 
-    // 	elements.push(rect, text)
-    // 	// label container
-    // 	const group: GroupNode = figma.group(elements, figma.currentPage)
-    // 	group.name = `${PREVIEW_ELEMENT_PREFIX} Label`
-    // 	const margin = 2 / zoom
-    // 	group.x = cloneRef.x
-    // 	group.y = cloneRef.y - height - margin
+	// 	elements.push(rect, text)
+	// 	// label container
+	// 	const group: GroupNode = figma.group(elements, figma.currentPage)
+	// 	group.name = `${PREVIEW_ELEMENT_PREFIX} Label`
+	// 	const margin = 2 / zoom
+	// 	group.x = cloneRef.x
+	// 	group.y = cloneRef.y - height - margin
 
-    // 	collapseLayer(group)
-    // 	return group
-    // }
+	// 	collapseLayer(group)
+	// 	return group
+	// }
 
-    function updateCanvasPreview(): void {
-        if (!selectionRef || !cloneRef) return
-        selectionRef.locked = true
-        selectionRef.visible = false
+	function updateCanvasPreview(): void {
+		if (!selectionRef || !cloneRef) return
+		selectionRef.locked = true
+		selectionRef.visible = false
 
-        cloneRef.locked = true
+		cloneRef.locked = true
 
-        // see L87
-        // if (!labelRef) {
-        // 	labelRef = createPreviewLabel() || undefined
-        // } else {
-        // 	labelRef.locked = true
+		// see L87
+		// if (!labelRef) {
+		// 	labelRef = createPreviewLabel() || undefined
+		// } else {
+		// 	labelRef.locked = true
 
-        // 	cloneRef.name = `${PREVIEW_ELEMENT_PREFIX} Easing Gradients`
-        // 	insertAfterNode(cloneRef, selectionRef)
-        // 	insertAfterNode(labelRef, selectionRef)
-        // }
+		// 	cloneRef.name = `${PREVIEW_ELEMENT_PREFIX} Easing Gradients`
+		// 	insertAfterNode(cloneRef, selectionRef)
+		// 	insertAfterNode(labelRef, selectionRef)
+		// }
 
-        updateGradientFill(cloneRef)
-    }
+		updateGradientFill(cloneRef)
+	}
 
-    function cleanUpCanvasPreview(): void {
-        if (!selectionRef || !cloneRef) return
-        selectionRef.locked = false
-        selectionRef.visible = true
-        selectionRef = undefined
+	function cleanUpCanvasPreview(): void {
+		if (!selectionRef || !cloneRef) return
+		selectionRef.locked = false
+		selectionRef.visible = true
+		selectionRef = undefined
 
-        cloneRef.remove()
-        cloneRef = undefined
+		cloneRef.remove()
+		cloneRef = undefined
 
-        if (labelRef) {
-            labelRef.remove()
-            labelRef = undefined
-        }
-    }
+		if (labelRef) {
+			labelRef.remove()
+			labelRef = undefined
+		}
+	}
 
-    /**
-     * Event handlers
-     */
-    function handleSelectionChange() {
-        const selectionState = validateSelection(figma.currentPage.selection)
-        if (selectionState !== 'VALID') {
-            cleanUpCanvasPreview()
-        } else {
-            const selection = figma.currentPage.selection[0]
-            if (cloneRef) {
-                // handle user selecting preview node via layer menu
-                if (selection.id === cloneRef.id) {
-                    cleanUpCanvasPreview()
-                    figma.notify(`Cannot select the preview element.`)
-                } else {
-                    cleanUpCanvasPreview()
-                    selectionRef = selection
-                    cloneRef = selectionRef.clone()
-                    makeSureClonedNodeIsInPlace()
-                    updateCanvasPreview()
-                }
-            } else {
-                selectionRef = selection
-                cloneRef = selectionRef.clone()
-                makeSureClonedNodeIsInPlace()
-                updateCanvasPreview()
-            }
-        }
-        const pluginData = checkIfExistingEasingData(selectionRef)
-        emit('UPDATE_SELECTION_STATE', { selectionState, pluginData })
-    }
+	/**
+	 * Event handlers
+	 */
+	function handleSelectionChange() {
+		const selectionState = validateSelection(figma.currentPage.selection)
+		if (selectionState !== 'VALID') {
+			cleanUpCanvasPreview()
+		} else {
+			const selection = figma.currentPage.selection[0]
+			if (cloneRef) {
+				// handle user selecting preview node via layer menu
+				if (selection.id === cloneRef.id) {
+					cleanUpCanvasPreview()
+					figma.notify(`Cannot select the preview element.`)
+				} else {
+					cleanUpCanvasPreview()
+					selectionRef = selection
+					cloneRef = selectionRef.clone()
+					makeSureClonedNodeIsInPlace()
+					updateCanvasPreview()
+				}
+			} else {
+				selectionRef = selection
+				cloneRef = selectionRef.clone()
+				makeSureClonedNodeIsInPlace()
+				updateCanvasPreview()
+			}
+		}
+		const pluginData = checkIfExistingEasingData(selectionRef)
+		emit('UPDATE_SELECTION_STATE', { selectionState, pluginData })
+	}
 
-    function handleUpdate(options: EasingOptions) {
-        state = { ...state, ...options }
-        updateCanvasPreview()
-    }
+	function handleUpdate(options: EasingOptions) {
+		state = { ...state, ...options }
+		updateCanvasPreview()
+	}
 
-    /**
-     * Makes sure that the cloneRef node has the same position as it's selectionRef master.
-     */
-    function makeSureClonedNodeIsInPlace(): void {
-        if (!selectionRef || !cloneRef) return
-        insertAfterNode(cloneRef, selectionRef)
-        if (selectionRef.parent?.type === 'GROUP') {
-            cloneRef.x = selectionRef.x
-            cloneRef.y = selectionRef.y
-        }
-    }
+	/**
+	 * Makes sure that the cloneRef node has the same position as it's selectionRef master.
+	 */
+	function makeSureClonedNodeIsInPlace(): void {
+		if (!selectionRef || !cloneRef) return
+		insertAfterNode(cloneRef, selectionRef)
+		if (selectionRef.parent?.type === 'GROUP') {
+			cloneRef.x = selectionRef.x
+			cloneRef.y = selectionRef.y
+		}
+	}
 
-    /**
-     * Handle preset getting/setting
-     */
-    async function handleInitialPresetEmitToUI(): Promise<void> {
-        getValueFromStoreOrInit(KEY_PRESETS, DEFAULT_PRESETS)
-            .then((response: PresetOptionValue) => {
-                emit('INITIALLY_EMIT_PRESETS_TO_UI', response)
-            })
-            .catch(() => {
-                figma.notify(
-                    `Couldn't load user presets, default presets will be used.`
-                )
-            })
-    }
+	/**
+	 * Handle preset getting/setting
+	 */
+	async function handleInitialPresetEmitToUI(): Promise<void> {
+		getValueFromStoreOrInit(KEY_PRESETS, DEFAULT_PRESETS)
+			.then((response: PresetOptionValue) => {
+				emit('INITIALLY_EMIT_PRESETS_TO_UI', response)
+			})
+			.catch(() => {
+				figma.notify(
+					`Couldn't load user presets, default presets will be used.`
+				)
+			})
+	}
 
-    async function handleReceivePresetsFromUI(data: any): Promise<void> {
-        const { presets, message } = data
-        setValueToStorage(KEY_PRESETS, presets)
-            .then((response: PresetOptionValue) => {
-                emit('RESPOND_TO_PRESETS_UPDATE', { response, message })
-                figma.notify(
-                    message === 'ADD' ? 'Added new preset.' : 'Removed preset.'
-                )
-            })
-            .catch(() => {
-                figma.notify(`Couldn't save preset, please try again.`)
-            })
-    }
+	async function handleReceivePresetsFromUI(data: any): Promise<void> {
+		const { presets, message } = data
+		setValueToStorage(KEY_PRESETS, presets)
+			.then((response: PresetOptionValue) => {
+				emit('RESPOND_TO_PRESETS_UPDATE', { response, message })
+				figma.notify(
+					message === 'ADD' ? 'Added new preset.' : 'Removed preset.'
+				)
+			})
+			.catch(() => {
+				figma.notify(`Couldn't save preset, please try again.`)
+			})
+	}
 
-    async function handleResetPresetsToDefault(): Promise<void> {
-        setValueToStorage(KEY_PRESETS, DEFAULT_PRESETS)
-            .then((response: PresetOptionValue) => {
-                emit('RESPOND_TO_PRESETS_UPDATE', {
-                    response,
-                    message: 'RESET',
-                })
-                figma.notify(
-                    'Removed all presets and restored default presets.'
-                )
-            })
-            .catch(() => {
-                figma.notify(`Couldn't reset preset, please try again.`)
-            })
-    }
+	async function handleResetPresetsToDefault(): Promise<void> {
+		setValueToStorage(KEY_PRESETS, DEFAULT_PRESETS)
+			.then((response: PresetOptionValue) => {
+				emit('RESPOND_TO_PRESETS_UPDATE', {
+					response,
+					message: 'RESET',
+				})
+				figma.notify(
+					'Removed all presets and restored default presets.'
+				)
+			})
+			.catch(() => {
+				figma.notify(`Couldn't reset preset, please try again.`)
+			})
+	}
 
-    function applyEasingFunction(): void {
-        if (!selectionRef) return
-        selectionRef.setRelaunchData({
-            ReapplyEasing: `Adjust gradient easing.`,
-            ResetEasing: `Reset gradient to what it was before easing was applied.`,
-        })
-        selectionRef.setPluginData(KEY_PLUGIN_DATA, JSON.stringify(state))
+	function applyEasingFunction(): void {
+		if (!selectionRef) return
+		selectionRef.setRelaunchData({
+			ReapplyEasing: `Adjust gradient easing.`,
+			ResetEasing: `Reset gradient to what it was before easing was applied.`,
+		})
+		selectionRef.setPluginData(KEY_PLUGIN_DATA, JSON.stringify(state))
 
-        updateGradientFill(selectionRef)
-        cleanUpCanvasPreview()
-        figma.closePlugin()
-    }
+		updateGradientFill(selectionRef)
+		cleanUpCanvasPreview()
+		figma.closePlugin()
+	}
 
-    // TODO: parse returned data, don't assume it has the correct type
-    function safeGetPluginData<T>(
-        selection: SceneNode | undefined,
-        key: string
-    ): T | undefined {
-        if (!selection) return
-        const pluginData = selection.getPluginData(key)
-        if (pluginData) {
-            try {
-                return JSON.parse(pluginData) as T
-            } catch {
-                return undefined
-            }
-        }
-        return undefined
-    }
+	// TODO: parse returned data, don't assume it has the correct type
+	function safeGetPluginData<T>(
+		selection: SceneNode | undefined,
+		key: string
+	): T | undefined {
+		if (!selection) return
+		const pluginData = selection.getPluginData(key)
+		if (pluginData) {
+			try {
+				return JSON.parse(pluginData) as T
+			} catch {
+				return undefined
+			}
+		}
+		return undefined
+	}
 
-    function checkIfExistingEasingData(
-        selection: SceneNode | undefined
-    ): EasingOptions | undefined {
-        return safeGetPluginData(selection, KEY_PLUGIN_DATA)
-    }
+	function checkIfExistingEasingData(
+		selection: SceneNode | undefined
+	): EasingOptions | undefined {
+		return safeGetPluginData(selection, KEY_PLUGIN_DATA)
+	}
 
-    /**
-     * Event listeners
-     */
-    on('UPDATE_FROM_UI', handleUpdate)
-    on('APPLY_EASING_FUNCTION', applyEasingFunction)
-    on('EMIT_PRESETS_TO_PLUGIN', handleReceivePresetsFromUI)
-    on('EMIT_PRESET_RESET_TO_PLUGIN', handleResetPresetsToDefault)
-    on('EMIT_NOTIFICATION_TO_PLUGIN', handleNotificationFromUI)
-    figma.on('selectionchange', handleSelectionChange)
-    figma.on('close', cleanUpCanvasPreview)
+	/**
+	 * Event listeners
+	 */
+	on('UPDATE_FROM_UI', handleUpdate)
+	on('APPLY_EASING_FUNCTION', applyEasingFunction)
+	on('EMIT_PRESETS_TO_PLUGIN', handleReceivePresetsFromUI)
+	on('EMIT_PRESET_RESET_TO_PLUGIN', handleResetPresetsToDefault)
+	on('EMIT_NOTIFICATION_TO_PLUGIN', handleNotificationFromUI)
+	figma.on('selectionchange', handleSelectionChange)
+	figma.on('close', cleanUpCanvasPreview)
 
-    /**
-     * If plugin was launched via RelaunchButton
-     */
-    if (figma.command === 'ReapplyEasing') {
-        const selection = figma.currentPage.selection[0]
-        const pluginData = checkIfExistingEasingData(selection)
-        if (pluginData) {
-            state = pluginData
-            updateGradientFill(selection)
-            figma.notify('Re-applied gradient easing.', { timeout: 3 })
-        }
-        selection.setRelaunchData({
-            ReapplyEasing: `Adjust gradient easing.`,
-            ResetEasing: `Reset gradient to what it was before easing was applied.`,
-        })
-        figma.closePlugin()
-    } else if (figma.command === 'ResetEasing') {
-        const selection = figma.currentPage.selection[0]
-        updateGradientFill(selection, true)
-        selection.setRelaunchData({
-            ReapplyEasing: `Add easing back.`,
-        })
-        figma.notify('Reset gradient easing.', { timeout: 3 })
-        figma.closePlugin()
-    } else {
-        showUI(ui)
-        handleInitialPresetEmitToUI()
-        handleSelectionChange()
-    }
+	/**
+	 * If plugin was launched via RelaunchButton
+	 */
+	if (figma.command === 'ReapplyEasing') {
+		const selection = figma.currentPage.selection[0]
+		const pluginData = checkIfExistingEasingData(selection)
+		if (pluginData) {
+			state = pluginData
+			updateGradientFill(selection)
+			figma.notify('Re-applied gradient easing.', { timeout: 3 })
+		}
+		selection.setRelaunchData({
+			ReapplyEasing: `Adjust gradient easing.`,
+			ResetEasing: `Reset gradient to what it was before easing was applied.`,
+		})
+		figma.closePlugin()
+	} else if (figma.command === 'ResetEasing') {
+		const selection = figma.currentPage.selection[0]
+		updateGradientFill(selection, true)
+		selection.setRelaunchData({
+			ReapplyEasing: `Add easing back.`,
+		})
+		figma.notify('Reset gradient easing.', { timeout: 3 })
+		figma.closePlugin()
+	} else {
+		showUI(ui)
+		handleInitialPresetEmitToUI()
+		handleSelectionChange()
+	}
 }

--- a/src/utils/gradient.ts
+++ b/src/utils/gradient.ts
@@ -13,9 +13,9 @@ import { EasingType, EasingOptions } from '../main'
  * @returns false if fill isn't a gradient fill, ex. SolidPaint or ImagePaint
  */
 export function isGradientFillWithMultipleStops(
-    fill: Paint
+	fill: Paint
 ): fill is GradientPaint {
-    return 'gradientStops' in fill && fill?.gradientStops?.length > 1
+	return 'gradientStops' in fill && fill?.gradientStops?.length > 1
 }
 
 /**
@@ -23,52 +23,52 @@ export function isGradientFillWithMultipleStops(
  * @returns Returns an array of color stops which represents the eased color gradient.
  */
 export function interpolateColorStops(
-    fill: GradientPaint,
-    options: EasingOptions
+	fill: GradientPaint,
+	options: EasingOptions
 ): ColorStop[] {
-    const { type, matrix, steps, skip } = options
-    const { gradientStops } = fill
+	const { type, matrix, steps, skip } = options
+	const { gradientStops } = fill
 
-    console.log('interpolating ', { options, gradientStops })
+	console.log('interpolating ', { options, gradientStops })
 
-    // How many color stops are used to interpolate between first and last stop
-    // TODO: Should this be an user-facing option?
-    const granularity = 15
+	// How many color stops are used to interpolate between first and last stop
+	// TODO: Should this be an user-facing option?
+	const granularity = 15
 
-    let stops: ColorStop[] = []
-    for (let i = 0; i < gradientStops.length - 1; i++) {
-        const start = gradientStops[i]
-        const end = gradientStops[i + 1]
+	let stops: ColorStop[] = []
+	for (let i = 0; i < gradientStops.length - 1; i++) {
+		const start = gradientStops[i]
+		const end = gradientStops[i + 1]
 
-        const coordinates =
-            type == 'CURVE'
-                ? easingCoordinates(
-                      `cubic-bezier(
+		const coordinates =
+			type == 'CURVE'
+				? easingCoordinates(
+						`cubic-bezier(
         				${matrix[0][0]},
         				${matrix[0][1]},
         				${matrix[1][0]},
         				${matrix[1][1]})`,
-                      granularity
-                  )
-                : easingCoordinates(`steps(${steps}, ${skip})`)
+						granularity
+				  )
+				: easingCoordinates(`steps(${steps}, ${skip})`)
 
-        // if we're not at the end, drop the last coordinate so we don't add redundant stops
-        if (i < gradientStops.length - 2) {
-            coordinates.pop()
-        }
+		// if we're not at the end, drop the last coordinate so we don't add redundant stops
+		if (i < gradientStops.length - 2) {
+			coordinates.pop()
+		}
 
-        stops = stops.concat(
-            coordinates.map((t) => {
-                const [r, g, b, a] = chroma
-                    .mix(gl(start), gl(end), t.y, 'rgb')
-                    .gl()
-                return {
-                    color: { r, g, b, a },
-                    position:
-                        start.position + t.x * (end.position - start.position),
-                }
-            })
-        )
-    }
-    return stops
+		stops = stops.concat(
+			coordinates.map((t) => {
+				const [r, g, b, a] = chroma
+					.mix(gl(start), gl(end), t.y, 'rgb')
+					.gl()
+				return {
+					color: { r, g, b, a },
+					position:
+						start.position + t.x * (end.position - start.position),
+				}
+			})
+		)
+	}
+	return stops
 }

--- a/src/utils/gradient.ts
+++ b/src/utils/gradient.ts
@@ -52,7 +52,7 @@ export function interpolateColorStops(
                   )
                 : easingCoordinates(`steps(${steps}, ${skip})`)
 
-        // if we're not at the end, drop the last coordinate
+        // if we're not at the end, drop the last coordinate so we don't add redundant stops
         if (i < gradientStops.length - 2) {
             coordinates.pop()
         }

--- a/src/utils/gradient.ts
+++ b/src/utils/gradient.ts
@@ -29,8 +29,6 @@ export function interpolateColorStops(
 	const { type, matrix, steps, skip } = options
 	const { gradientStops } = fill
 
-	console.log('interpolating ', { options, gradientStops })
-
 	// How many color stops are used to interpolate between first and last stop
 	// TODO: Should this be an user-facing option?
 	const granularity = 15


### PR DESCRIPTION
- support multi-stop gradients
- saves previous gradient stops to plugin data so they can be restored
- add reset plugin action

I needed to store the original gradient fills to implement multi-stop so this is a combined PR since reset is trivial at that point.

https://user-images.githubusercontent.com/355540/175380854-b409c269-e20f-444e-8f30-5f905e4570dc.mov

There are a few details with the way that stops are restored that aren't 100% idea/sure:
- if you edit just end colors like you used to be able to before re-applying, your changes are blown away. maybe I could detect this case better?
- I assume that you don't reorder your gradient fills, but you can add other non-gradient fills

fixes #1 